### PR TITLE
Bugfix In-game font settings not working

### DIFF
--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -3321,8 +3321,8 @@ void catacurses::init_interface()
 
     font_loader fl;
     fl.load();
-    ::fontwidth = get_option<int>( "FONT_WIDTH" );
-    ::fontheight = get_option<int>( "FONT_HEIGHT" );
+    fl.fontwidth = get_option<int>( "FONT_WIDTH" );
+    fl.fontheight = get_option<int>( "FONT_HEIGHT" );
     fl.fontsize = get_option<int>( "FONT_SIZE" );
     fl.fontblending = get_option<bool>( "FONT_BLENDING" );
     fl.map_fontsize = get_option<int>( "MAP_FONT_SIZE" );
@@ -3331,6 +3331,8 @@ void catacurses::init_interface()
     fl.overmap_fontsize = get_option<int>( "OVERMAP_FONT_SIZE" );
     fl.overmap_fontwidth = get_option<int>( "OVERMAP_FONT_WIDTH" );
     fl.overmap_fontheight = get_option<int>( "OVERMAP_FONT_HEIGHT" );
+    ::fontwidth = fl.fontwidth;
+    ::fontheight = fl.fontheight;
 
     InitSDL();
 


### PR DESCRIPTION
#### Summary
```SUMMARY: Bugfixes "In-game font settings not working"```

#### Purpose of change
```Fixes #29411 - In-game font settings not working```

#### Describe the solution
fl.fontwidth and fl.fontheight in src/sdltiles.cpp was still in use to "Reset the font pointer" and was no longer being set in catacurses::init_interface() after #28122. Change sets them by the new in-game options before loading into ::fontwidth and ::fontheight.

#### Describe alternatives you've considered
Better / future solution may be to replace reference to fl.fontwidth and fl.fontheight in:
src/sdltiles.cpp
// Reset the font pointer
font = Font::load_font( fl.typeface, fl.fontsize, fl.fontwidth, fl.fontheight, fl.fontblending );


